### PR TITLE
fix: remove sidebar import

### DIFF
--- a/src/components/DocsLayout/index.js
+++ b/src/components/DocsLayout/index.js
@@ -14,7 +14,6 @@ import EditPage from "./EditPage";
 import Contributors from "./Contributors";
 import NodeNavigation from "./NodeNavigation";
 import DocsContent from "../DocsContent";
-import SidebarContainer from "../SidebarContainer";
 
 const DocsLayout = ({ data }) => {
   const { mdx, allMdx } = data;


### PR DESCRIPTION
### Description

This pull request removes the sidebar import that is causing the build to fail. The import is trying to use a folder name that does not exist.