### PR TITLE
fix: v3 network ids

### DIFF
--- a/docs/developer/protocol/deployments/index.md
+++ b/docs/developer/protocol/deployments/index.md
@@ -69,8 +69,8 @@ The protocol uses `centrifugeId` (`uint16`) as an identifier of the network. The
 | Ethereum Mainnet | 1  |
 | Base             | 2  |
 | Arbitrum         | 3  |
-| Avalanche        | 4  |
-| Plume            | 5  |
+| Plume            | 4  |
+| Avalanche        | 5  |
 
 ### Testnet
 


### PR DESCRIPTION
Fixes mixed up Centrifuge network ids of Plume ([4 instead of current 5](https://github.com/centrifuge/protocol-v3/blob/6f60024a3d49d83a2efc1611756e6ab229c333fc/env/plume.json#L5)) and Avalanche ([5 instead of current 4](https://github.com/centrifuge/protocol-v3/blob/6f60024a3d49d83a2efc1611756e6ab229c333fc/env/avalanche.json#L5))