### PR TITLE
ci: build docs and verify deployment addresses against the API

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,26 @@
+name: Build docs
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build

--- a/.github/workflows/verify-deployments.yml
+++ b/.github/workflows/verify-deployments.yml
@@ -1,0 +1,33 @@
+name: Verify deployments
+
+# Cross-checks the addresses on the Deployments page against the Centrifuge API.
+# Runs only when that page (or the verification script) changes.
+on:
+  pull_request:
+    paths:
+      - docs/developer/protocol/deployments/**
+  push:
+    branches: [main]
+    paths:
+      - docs/developer/protocol/deployments/**
+  workflow_dispatch:
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      # Contract addresses (Core, Adapters, Admin, Hooks, Managers, Valuations,
+      # Vaults tabs) against the Deployment entity.
+      - name: Verify contract addresses against the Deployment entity
+        run: node scripts/verify-deployments.mjs --scope=contracts
+
+      # Token and vault addresses against the TokenInstance and Vault entities.
+      - name: Verify token and vault addresses against the API
+        if: '!cancelled()'
+        run: node scripts/verify-deployments.mjs --scope=tokens,vaults

--- a/scripts/verify-deployments.mjs
+++ b/scripts/verify-deployments.mjs
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+// Verify the addresses on the Deployments page against the Centrifuge API.
+//
+// The page at docs/developer/protocol/deployments/index.mdx lists protocol
+// contract addresses, token addresses, and vault addresses. This script cross
+// checks each address (both the text shown and the address inside its explorer
+// link) against the public Centrifuge API (https://api.centrifuge.io):
+//
+//   contracts  -> Deployment entity (per-network protocol contract addresses)
+//   tokens     -> TokenInstance entity (per-network share-class token addresses)
+//   vaults     -> Vault entity (per-network vault contract addresses)
+//
+// Usage:
+//   node scripts/verify-deployments.mjs --scope=contracts
+//   node scripts/verify-deployments.mjs --scope=tokens,vaults
+//   node scripts/verify-deployments.mjs                 # all scopes
+//
+// Exit code is non-zero when any error is found. Warnings never fail the run.
+
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const API_URL = process.env.CENTRIFUGE_API_URL || 'https://api.centrifuge.io';
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PAGE = resolve(HERE, '../docs/developer/protocol/deployments/index.mdx');
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+let scopeArg = 'contracts,tokens,vaults';
+let pagePath = DEFAULT_PAGE;
+for (const arg of process.argv.slice(2)) {
+  if (arg.startsWith('--scope=')) scopeArg = arg.slice('--scope='.length);
+  else if (arg.startsWith('--page=')) pagePath = resolve(process.cwd(), arg.slice('--page='.length));
+  else if (!arg.startsWith('--')) pagePath = resolve(process.cwd(), arg);
+}
+const scopes = new Set(scopeArg.split(',').map((s) => s.trim()).filter(Boolean));
+
+// ---------------------------------------------------------------------------
+// Static maps
+// ---------------------------------------------------------------------------
+
+// Network name / icon alt text (lowercased, matched as a substring) -> centrifugeId.
+const NETWORK_IDS = {
+  ethereum: '1',
+  base: '2',
+  arbitrum: '3',
+  plume: '4',
+  avalanche: '5',
+  binance: '6',
+  bnb: '6',
+  bsc: '6',
+  solana: '7',
+  stellar: '8',
+  hyperevm: '9',
+  optimism: '10',
+  monad: '11',
+  pharos: '12',
+};
+// Non-EVM networks are not covered by the API address lookups below; skip them.
+const NON_EVM_IDS = new Set(['7', '8']);
+
+function networkToId(name) {
+  const n = name.trim().toLowerCase();
+  for (const [key, id] of Object.entries(NETWORK_IDS)) {
+    if (n.includes(key)) return id;
+  }
+  return null;
+}
+
+// Deployments page contract label -> Deployment entity field.
+const CONTRACT_FIELDS = {
+  Hub: 'hub',
+  'Hub Registry': 'hubRegistry',
+  Accounting: 'accounting',
+  Holdings: 'holdings',
+  'Share Class Manager': 'shareClassManager',
+  'Hub Handler': 'hubHandler',
+  Spoke: 'spoke',
+  'Balance Sheet': 'balanceSheet',
+  'Token Factory': 'tokenFactory',
+  'Vault Registry': 'vaultRegistry',
+  'Pool Escrow Factory': 'poolEscrowFactory',
+  Gateway: 'gateway',
+  'Multi Adapter': 'multiAdapter',
+  'Message Processor': 'messageProcessor',
+  'Message Dispatcher': 'messageDispatcher',
+  'Gas Service': 'gasService',
+  'Contract Updater': 'contractUpdater',
+  'LayerZero Adapter': 'layerZeroAdapter',
+  'Chainlink Adapter': 'chainlinkAdapter',
+  'Axelar Adapter': 'axelarAdapter',
+  'Wormhole Adapter': 'wormholeAdapter',
+  Root: 'root',
+  'Protocol Guardian': 'protocolGuardian',
+  'Ops Guardian': 'opsGuardian',
+  'Token Recoverer': 'tokenRecoverer',
+  'Freeze Only Hook': 'freezeOnlyHook',
+  'Full Restrictions Hook': 'fullRestrictionsHook',
+  'Freely Transferable Hook': 'freelyTransferableHook',
+  'Redemption Restrictions Hook': 'redemptionRestrictionsHook',
+  'NAV Manager': 'navManager',
+  'Simple Price Manager': 'simplePriceManager',
+  'On/Offramp Manager Factory': 'onOfframpManagerFactory',
+  'Merkle Proof Manager Factory': 'merkleProofManagerFactory',
+  'Queue Manager': 'queueManager',
+  'Vault Decoder': 'vaultDecoder',
+  'Circle Decoder': 'circleDecoder',
+  'Identity Valuation': 'identityValuation',
+  'Oracle Valuation': 'oracleValuation',
+  'Async Vault Factory': 'asyncVaultFactory',
+  'Sync Deposit Vault Factory': 'syncDepositVaultFactory',
+  'Vault Router': 'vaultRouter',
+  'Async Request Manager': 'asyncRequestManager',
+  'Sync Manager': 'syncManager',
+  'Batch Request Manager': 'batchRequestManager',
+  'Refund Escrow Factory': 'refundEscrowFactory',
+  'Subsidy Manager': 'subsidyManager',
+};
+
+const ADDR = /0x[0-9a-fA-F]{40}/;
+
+// ---------------------------------------------------------------------------
+// Findings
+// ---------------------------------------------------------------------------
+const errors = [];
+const warnings = [];
+let checked = 0;
+const err = (line, msg) => errors.push({ line, msg });
+const warn = (line, msg) => warnings.push({ line, msg });
+
+// ---------------------------------------------------------------------------
+// API access
+// ---------------------------------------------------------------------------
+async function gql(query) {
+  const res = await fetch(API_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query }),
+  });
+  if (!res.ok) throw new Error(`API request failed: HTTP ${res.status}`);
+  const json = await res.json();
+  if (json.errors) throw new Error(`API returned errors: ${JSON.stringify(json.errors)}`);
+  return json.data;
+}
+
+async function fetchDeployments() {
+  const fields = [...new Set(Object.values(CONTRACT_FIELDS))].join(' ');
+  const data = await gql(`{ deployments(limit: 200) { items { centrifugeId ${fields} } } }`);
+  const byId = {};
+  for (const item of data.deployments.items) {
+    const { centrifugeId, ...rest } = item;
+    byId[centrifugeId] = rest;
+  }
+  return byId;
+}
+
+// Returns Map<addressLower, Set<centrifugeId>>.
+async function fetchAddressIndex(entity, idField) {
+  const data = await gql(`{ ${entity}(limit: 1000) { items { ${idField} centrifugeId } pageInfo { hasNextPage } } }`);
+  if (data[entity].pageInfo?.hasNextPage) {
+    warn(0, `API returned a full page for ${entity}; results may be truncated (pagination not implemented).`);
+  }
+  const map = new Map();
+  for (const item of data[entity].items) {
+    const addr = String(item[idField]).toLowerCase();
+    if (!map.has(addr)) map.set(addr, new Set());
+    map.get(addr).add(String(item.centrifugeId));
+  }
+  return map;
+}
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+function tableCells(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return null;
+  return trimmed.slice(1, trimmed.endsWith('|') ? -1 : undefined).split('|').map((c) => c.trim());
+}
+
+// Extracts the displayed address (in `backticks` or [brackets]) and the address
+// inside the explorer link from a "| ... [`0x..`](https://.../0x..) |" cell.
+function extractAddressLink(text) {
+  const linkMatch = text.match(/\[([^\]]*)\]\((https?:\/\/[^)]+)\)/);
+  if (!linkMatch) return null;
+  const display = (linkMatch[1].match(ADDR) || [])[0] || null;
+  const link = (linkMatch[2].match(ADDR) || [])[0] || null;
+  return { display, link };
+}
+
+// ---------------------------------------------------------------------------
+// Scope: contracts
+// ---------------------------------------------------------------------------
+function parseContracts(lines) {
+  const rows = [];
+  let inSection = false;
+  lines.forEach((raw, i) => {
+    if (raw.startsWith('## Smart contracts')) inSection = true;
+    else if (inSection && raw.startsWith('## ')) inSection = false;
+    if (!inSection) return;
+
+    const cells = tableCells(raw);
+    if (!cells || cells.length < 3) return;
+    const label = cells[0];
+    const addrCell = cells[1];
+    // A contract row has an address (or "-") in the second column.
+    if (!/^`?(0x[0-9a-fA-F]{40}|-)`?$/.test(addrCell)) return;
+
+    const display = (addrCell.match(ADDR) || [])[0] || null;
+    const links = [];
+    const linkRe = /alt="([^"]+)"[^\]]*?\]\((https?:\/\/[^)]+)\)/g;
+    let m;
+    while ((m = linkRe.exec(cells[2])) !== null) {
+      const addr = (m[2].match(ADDR) || [])[0];
+      if (addr) links.push({ network: m[1], id: networkToId(m[1]), addr });
+    }
+    rows.push({ label, display, links, line: i + 1 });
+  });
+  return rows;
+}
+
+function checkContracts(rows, deployments) {
+  for (const row of rows) {
+    const field = CONTRACT_FIELDS[row.label];
+    if (!field) {
+      warn(row.line, `Unknown contract "${row.label}" — no Deployment field mapped, skipping API check.`);
+    }
+    for (const link of row.links) {
+      checked++;
+      // Displayed address must match the address it links to.
+      if (row.display && row.display.toLowerCase() !== link.addr.toLowerCase()) {
+        err(row.line, `${row.label}: displayed ${row.display} but ${link.network} link points to ${link.addr}.`);
+      }
+      if (!link.id) {
+        warn(row.line, `${row.label}: unrecognized network "${link.network}".`);
+        continue;
+      }
+      if (!field) continue;
+      const apiAddr = deployments[link.id]?.[field];
+      if (apiAddr == null) {
+        err(row.line, `${row.label}: page lists it on ${link.network} (cid ${link.id}) but the API has no deployment there.`);
+        continue;
+      }
+      if (apiAddr.toLowerCase() !== link.addr.toLowerCase()) {
+        err(row.line, `${row.label} on ${link.network}: page ${link.addr} != API ${apiAddr}.`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Scope: tokens / vaults
+// ---------------------------------------------------------------------------
+function parseAssetSection(lines, startHeading, endHeading) {
+  const entries = [];
+  let inSection = false;
+  let symbol = null;
+  lines.forEach((raw, i) => {
+    if (raw.trim() === startHeading) { inSection = true; return; }
+    if (inSection && raw.trim() === endHeading) { inSection = false; return; }
+    if (!inSection) return;
+
+    const h = raw.match(/^#{3,4}\s+(.+)$/);
+    if (h) { symbol = h[1].trim(); return; }
+
+    const cells = tableCells(raw);
+    if (!cells) return;
+    const network = cells[0];
+    if (!network || /^-+$/.test(network) || /^network$/i.test(network)) return; // separator / header
+
+    const link = extractAddressLink(raw);
+    if (!link || !link.display) return; // non-EVM (e.g. Solana/Stellar) or no link
+    entries.push({ symbol, network, id: networkToId(network), ...link, line: i + 1 });
+  });
+  return entries;
+}
+
+function checkAssets(entries, index, kind) {
+  for (const e of entries) {
+    checked++;
+    // Displayed address must match the address it links to.
+    if (e.display && e.link && e.display.toLowerCase() !== e.link.toLowerCase()) {
+      err(e.line, `${kind} ${e.symbol} on ${e.network}: displayed ${e.display} but link points to ${e.link}.`);
+    }
+    if (e.id && NON_EVM_IDS.has(e.id)) continue; // non-EVM not indexed by these lookups
+    const candidates = [...new Set([e.display, e.link].filter(Boolean).map((a) => a.toLowerCase()))];
+    for (const addr of candidates) {
+      const ids = index.get(addr);
+      if (!ids) {
+        err(e.line, `${kind} ${e.symbol} on ${e.network}: ${addr} not found in API ${kind} list.`);
+      } else if (e.id && !ids.has(e.id)) {
+        warn(e.line, `${kind} ${e.symbol}: ${addr} is on cid [${[...ids].join(', ')}], not ${e.network} (cid ${e.id}).`);
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+async function main() {
+  const source = await readFile(pagePath, 'utf8');
+  const lines = source.split('\n');
+
+  if (scopes.has('contracts')) {
+    const rows = parseContracts(lines);
+    if (rows.length === 0) warn(0, 'No contract rows parsed — page structure may have changed.');
+    checkContracts(rows, await fetchDeployments());
+  }
+  if (scopes.has('tokens')) {
+    const entries = parseAssetSection(lines, '## Tokens', '## Vaults');
+    if (entries.length === 0) warn(0, 'No token rows parsed — page structure may have changed.');
+    checkAssets(entries, await fetchAddressIndex('tokenInstances', 'address'), 'token');
+  }
+  if (scopes.has('vaults')) {
+    const entries = parseAssetSection(lines, '## Vaults', ' ');
+    if (entries.length === 0) warn(0, 'No vault rows parsed — page structure may have changed.');
+    checkAssets(entries, await fetchAddressIndex('vaults', 'id'), 'vault');
+  }
+
+  const at = (line) => (line ? `  L${line}` : '  ');
+  if (warnings.length) {
+    console.log(`\n⚠  ${warnings.length} warning(s):`);
+    for (const w of warnings) console.log(`${at(w.line)}  ${w.msg}`);
+  }
+  if (errors.length) {
+    console.error(`\n✖  ${errors.length} error(s) in ${pagePath}:`);
+    for (const e of errors) console.error(`${at(e.line)}  ${e.msg}`);
+    console.error(`\nChecked ${checked} address entr(ies) for scope: ${[...scopes].join(', ')}.`);
+    process.exit(1);
+  }
+  console.log(`\n✔  ${checked} address entr(ies) verified for scope: ${[...scopes].join(', ')}.`);
+}
+
+main().catch((e) => {
+  console.error(`verify-deployments: ${e.message}`);
+  process.exit(2);
+});


### PR DESCRIPTION
## What

Two GitHub Actions workflows:

### 1. `build.yml` — build the docs
Runs `pnpm build` on every PR and push to `main` to catch build breakages.

### 2. `verify-deployments.yml` — validate the Deployments page against the API
Triggered only when `docs/developer/protocol/deployments/**` changes. It cross-checks every address on the [Deployments](https://docs.centrifuge.io/developer/protocol/deployments) page against the public [Centrifuge API](https://docs.centrifuge.io/developer/centrifuge-api/), in two steps:

- **Contract addresses** → the `Deployment` entity (per-network protocol contracts).
- **Token and vault addresses** → the `TokenInstance` and `Vault` entities.

The logic lives in `scripts/verify-deployments.mjs` (Node, no dependencies). It fails the build when:
- a page address doesn't match the API for that contract/network;
- the page shows a contract/token/vault on a network where the API has no deployment;
- the address shown in text differs from the address its explorer link points to.

Network-level mismatches for tokens/vaults (address valid but indexed on a different chain) are reported as warnings to avoid flakiness from indexer lag.

## Verification — does it catch the issues fixed by #636?

Yes. Run against the current (pre-#636) page it reports **8 errors**, each a real problem in scope of #636:

```
L51  Axelar Adapter: page lists it on Pharos (cid 12) but the API has no deployment there.
L52  Wormhole Adapter on Avalanche: page 0x4BE4…706A7 != API 0x6b98…39ec.
L52  Wormhole Adapter: page lists it on Plume (cid 4) but the API has no deployment there.
L52  Wormhole Adapter on BSC: page 0x4BE4…706A7 != API 0x6b98…39ec.
L226 token deSPXA on Base: displayed 0x9c5C…9685 but link points to 0x2da4…393a.
L226 token deSPXA on Base: 0x2da4…393a not found in API token list.
L249 vault JAAA on Base: displayed 0x2AEf…Ef0b but link points to 0x4880…780b.
L285 vault deJAAA on Arbitrum: displayed 0xe897…7d6e but link points to 0x498b…21d2.
```

Run against the **fixed page from #636**, it passes clean: `✔ 541 address entries verified`.

## Notes
- The `verify-deployments` job will fail on any PR that edits the Deployments page while `main` still carries the pre-#636 addresses — that's intended, and it goes green once #636 (or an equivalent address fix) lands.
- The build workflow intentionally does not run `pnpm typecheck`: there are pre-existing type errors in `GraphQLExplorer`/`RESTExplorer` unrelated to this change. Happy to add a typecheck step in a follow-up once those are fixed.
