### PR TITLE
ci: catch broken links in the docs

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,55 @@
+name: Link check
+
+# Catches broken links in the docs: dead external links (404s, etc.) and
+# malformed URL schemes (e.g. a "ttps://" typo). Internal links are validated
+# by the Docusaurus build (see build.yml).
+on:
+  pull_request:
+    paths:
+      - docs/**
+  workflow_dispatch:
+
+jobs:
+  # Fast, deterministic, no network. Runs over all docs.
+  malformed-schemes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Check for malformed link schemes
+        run: node scripts/check-link-schemes.mjs
+
+  # Checks external links reachable. On a PR it only checks the changed docs
+  # files, so a PR is judged on the links it touches. A manual run
+  # (workflow_dispatch) checks the whole docs tree.
+  dead-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine files to check
+        id: scope
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            files=$(git diff --name-only --diff-filter=d \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              -- docs | grep -E '\.mdx?$' || true)
+          else
+            files=$(git ls-files docs | grep -E '\.mdx?$')
+          fi
+          files=$(echo "$files" | tr '\n' ' ')
+          echo "files=$files" >> "$GITHUB_OUTPUT"
+          [ -z "$(echo "$files" | tr -d ' ')" ] && echo "empty=true" >> "$GITHUB_OUTPUT" || true
+
+      - name: Check links with lychee
+        if: steps.scope.outputs.empty != 'true'
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config lychee.toml --no-progress ${{ steps.scope.outputs.files }}
+          fail: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     paths:
       - docs/**
+      - scripts/check-link-schemes.mjs
+      - lychee.toml
+      - .github/workflows/link-check.yml
   workflow_dispatch:
 
 jobs:
@@ -48,7 +51,7 @@ jobs:
 
       - name: Check links with lychee
         if: steps.scope.outputs.empty != 'true'
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: --config lychee.toml --no-progress ${{ steps.scope.outputs.files }}
           fail: true

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ yarn-error.log*
 
 .yarn
 .cache
+# lychee link-checker cache
+.lycheecache

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,57 @@
+# Configuration for the lychee link checker (used by .github/workflows/link-check.yml).
+#
+# lychee validates external (http/https) links. Internal links are resolved
+# against a sentinel base URL and then excluded, because the Docusaurus build
+# already validates internal links against the real route table (onBrokenLinks).
+
+# Resolve root-relative and relative links against this sentinel host so they
+# become regular URLs, then exclude the host below. Without a base URL, lychee
+# errors on root-relative links ("cannot resolve").
+base_url = "https://internal.invalid"
+
+# Only check web links.
+scheme = ["https", "http"]
+
+# Retry transient failures before giving up.
+max_retries = 3
+retry_wait_time = 2
+timeout = 20
+
+# Some servers reject HEAD; fall back to GET.
+method = "get"
+
+# Treat success plus rate-limiting as acceptable, so CI does not fail on 429s.
+accept = ["200..=299", "429"]
+
+# Skip internal links (now under the sentinel host), local dev URLs, and the
+# auth-walled legacy Tinlake app (returns 401).
+exclude = [
+  "^https?://internal\\.invalid",
+  "^https?://localhost",
+  "^https?://127\\.0\\.0\\.1",
+  "^https?://legacy\\.tinlake\\.centrifuge\\.io",
+  # Block explorers bot-block automated requests (403). The addresses they link
+  # to are validated against the API by the verify-deployments workflow.
+  "etherscan\\.io",
+  "basescan\\.org",
+  "arbiscan\\.io",
+  "snowscan\\.xyz",
+  "snowtrace\\.io",
+  "bscscan\\.com",
+  "monadscan\\.com",
+  "pharosscan\\.xyz",
+  "hyperevmscan\\.io",
+  "explorer\\.plume\\.org",
+  "solscan\\.io",
+  "stellar\\.expert",
+]
+
+# Skip archived legacy docs, where external link rot is expected.
+exclude_path = [
+  "docs/developer/legacy",
+  "docs/getting-started/legacy",
+]
+
+# Cache results between runs to reduce load and flakiness.
+cache = true
+max_cache_age = "2d"

--- a/scripts/check-link-schemes.mjs
+++ b/scripts/check-link-schemes.mjs
@@ -9,7 +9,7 @@
 
 import { readdir, readFile } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
-import { dirname, join, resolve, relative } from 'node:path';
+import { dirname, resolve, relative } from 'node:path';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(HERE, '..');
@@ -36,7 +36,8 @@ async function* walk(dir) {
     return;
   }
   for (const e of entries) {
-    const p = join(dir, e.name);
+    const p = resolve(dir, e.name);
+    if (relative(dir, p).startsWith('..')) continue; // never escape the scanned dir
     if (e.isDirectory()) yield* walk(p);
     else if (EXTENSIONS.has(p.slice(p.lastIndexOf('.')))) yield p;
   }

--- a/scripts/check-link-schemes.mjs
+++ b/scripts/check-link-schemes.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Flag links whose URL scheme is malformed — e.g. a typo like `ttps://` instead
+// of `https://`. External link checkers (lychee) treat such schemes as
+// "unsupported" and skip them, so they slip through unnoticed. This guard scans
+// the docs for markdown link targets and HTML href/src values and fails on any
+// scheme outside a small allowlist.
+//
+// Usage: node scripts/check-link-schemes.mjs [dir ...]   (default: docs)
+
+import { readdir, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve, relative } from 'node:path';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(HERE, '..');
+const roots = process.argv.slice(2).length
+  ? process.argv.slice(2).map((d) => resolve(process.cwd(), d))
+  : [resolve(ROOT, 'docs')];
+
+const ALLOWED_SCHEMES = new Set(['https', 'http', 'mailto', 'tel']);
+const EXTENSIONS = new Set(['.md', '.mdx']);
+
+// Any "scheme://" prefix. A valid URI scheme is letter followed by letters,
+// digits, +, -, or . (RFC 3986).
+const SCHEME = /^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//;
+// Markdown link target: ](  target ) — allow an optional <...> wrapper.
+const MD_LINK = /\]\(\s*<?([^)\s>]+)/g;
+// HTML attribute: href="..." or src="..."
+const HTML_ATTR = /\b(?:href|src)\s*=\s*"([^"]+)"/g;
+
+async function* walk(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const e of entries) {
+    const p = join(dir, e.name);
+    if (e.isDirectory()) yield* walk(p);
+    else if (EXTENSIONS.has(p.slice(p.lastIndexOf('.')))) yield p;
+  }
+}
+
+function lineOf(text, index) {
+  return text.slice(0, index).split('\n').length;
+}
+
+const errors = [];
+let scanned = 0;
+
+for (const root of roots) {
+  for await (const file of walk(root)) {
+    scanned++;
+    const text = await readFile(file, 'utf8');
+    for (const re of [MD_LINK, HTML_ATTR]) {
+      re.lastIndex = 0;
+      let m;
+      while ((m = re.exec(text)) !== null) {
+        const target = m[1];
+        const scheme = target.match(SCHEME)?.[1];
+        if (scheme && !ALLOWED_SCHEMES.has(scheme.toLowerCase())) {
+          errors.push({
+            file: relative(process.cwd(), file),
+            line: lineOf(text, m.index),
+            target,
+            scheme,
+          });
+        }
+      }
+    }
+  }
+}
+
+if (errors.length) {
+  console.error(`\n✖  ${errors.length} malformed link scheme(s):`);
+  for (const e of errors) {
+    console.error(`  ${e.file}:${e.line}  "${e.scheme}://" — ${e.target}`);
+  }
+  console.error(`\nAllowed schemes: ${[...ALLOWED_SCHEMES].join(', ')}. Did you mean "https"?`);
+  process.exit(1);
+}
+
+console.log(`✔  no malformed link schemes in ${scanned} file(s).`);


### PR DESCRIPTION
## What

A `link-check` workflow that catches broken links in the docs, with two guards:

### `malformed-schemes` — typo'd URL schemes
`scripts/check-link-schemes.mjs` flags link targets whose scheme isn't in a small allowlist (`https`, `http`, `mailto`, `tel`) — e.g. `ttps://…`. External checkers treat these as "unsupported" and silently skip them, so they otherwise go unnoticed. Fast, deterministic, no network; runs over all docs.

### `dead-links` — unreachable external links
Uses [lychee](https://github.com/lycheeverse/lychee-action). On a PR it checks **only the changed docs files**, so a PR is judged on the links it touches; a manual `workflow_dispatch` run scans the whole docs tree.

`lychee.toml` keeps it focused and non-flaky:
- internal links are left to the Docusaurus build (`build.yml`), which resolves them against the route table;
- block explorers (etherscan/arbiscan/snowtrace/…) are excluded — they bot-block with 403, and their addresses are already validated by the `verify-deployments` workflow;
- archived legacy docs are skipped (external link rot expected there).

## Catches the reported cases

Both examples from the request are caught:
- `https://…/src/vaults/OnOffRampManager.sol` (wrong path) → **404**, flagged by lychee.
- `ttps://…/OnOfframpManager.sol` (malformed scheme) → flagged by the scheme guard.

## Known pre-existing broken links (not fixed here — separate PR)

A full local run surfaced 9 real dead links in current (non-legacy) docs, to be fixed separately:

- `docs/developer/protocol/deployments/index.mdx` — GitHub `Code` links for `OnOfframpManager`, `MerkleProofManager`, `VaultDecoder`, `CircleDecoder` (404). These are already fixed in #636.
- `docs/developer/protocol/integration-patterns/custom-balance-sheet-managers/index.md` — `src/vaults/OnOffRampManager.sol`, `src/vaults/OnchainPortfolioManager.sol` (404).
- `docs/developer/security/pool-access-levels.md` — `src/managers/spoke/OnOfframpManager.sol`, `MerkleProofManager.sol` (404).
- `docs/getting-started/introduction/mission-and-history/index.md` — `https://www.rwa.xyz/tokenized-asset-coalition` (404; moved to `app.rwa.xyz`).

Because PR runs are scoped to changed files, these don't block unrelated PRs; they'll be caught when their files are next edited (or via a manual full run).
