### PR TITLE
ci: run deployment verification when its script or workflow change

### DIFF
--- a/.github/workflows/verify-deployments.yml
+++ b/.github/workflows/verify-deployments.yml
@@ -6,10 +6,14 @@ on:
   pull_request:
     paths:
       - docs/developer/protocol/deployments/**
+      - scripts/verify-deployments.mjs
+      - .github/workflows/verify-deployments.yml
   push:
     branches: [main]
     paths:
       - docs/developer/protocol/deployments/**
+      - scripts/verify-deployments.mjs
+      - .github/workflows/verify-deployments.yml
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Extends the `verify-deployments` triggers so the check also runs when `scripts/verify-deployments.mjs` or `.github/workflows/verify-deployments.yml` change — not only when the Deployments page changes. This validates edits to the checker itself.

Companion to #639, which does the same for the link-check workflow.

> [!NOTE]
> This PR's `verify-deployments` run will fail: `main`'s Deployments page still carries the pre-#636 address issues the check is designed to catch (Axelar-on-Pharos, wrong Wormhole addresses, token/vault display-vs-link mismatches). It goes green once #636 (the address fixes) lands.