### PR TITLE
docs(protocol): NAV and oracles guide + pricePerShare share-price FAQ

### DIFF
--- a/docs/developer/protocol/guides/bridge-share-tokens/_category_.yml
+++ b/docs/developer/protocol/guides/bridge-share-tokens/_category_.yml
@@ -1,1 +1,1 @@
-position: 6
+position: 7

--- a/docs/developer/protocol/guides/deploy-vaults/_category_.yml
+++ b/docs/developer/protocol/guides/deploy-vaults/_category_.yml
@@ -1,1 +1,1 @@
-position: 3
+position: 4

--- a/docs/developer/protocol/guides/invest-into-a-vault/_category_.yml
+++ b/docs/developer/protocol/guides/invest-into-a-vault/_category_.yml
@@ -1,1 +1,1 @@
-position: 4
+position: 5

--- a/docs/developer/protocol/guides/invest-into-a-vault/index.md
+++ b/docs/developer/protocol/guides/invest-into-a-vault/index.md
@@ -118,7 +118,13 @@ Asynchronous requests are fulfilled by the pool issuer. The time to fulfillment 
 
 ### How do I get the current share price?
 
-Use `vault.convertToAssets()` to convert a share amount to its current value in the investment asset:
+Use `vault.pricePerShare()` to read the latest price of one share, quoted in the investment asset's decimals (e.g., 6 for USDC):
+
+```solidity
+uint256 sharePrice = vault.pricePerShare();
+```
+
+This is the preferred way to get the latest price. Alternatively, `vault.convertToAssets()` converts a specific share amount to its current value in the investment asset:
 
 ```solidity
 uint8 shareDecimals = vault.share().decimals();
@@ -126,10 +132,10 @@ uint256 oneShare = 10 ** shareDecimals;
 uint256 assetValue = vault.convertToAssets(oneShare);
 ```
 
-The result is denominated in the investment asset and uses the asset's decimals (e.g., 6 for USDC).
+Both are denominated in the investment asset and use the asset's decimals.
 
 :::info
-The price returned by `convertToAssets()` may not be the exact price at which a request is settled, since there can be a time lag between querying and fulfillment.
+These prices may not be the exact price at which a request is settled, since there can be a time lag between querying and fulfillment.
 :::
 
 ### Who pays for cross-chain gas?

--- a/docs/developer/protocol/guides/manage-a-pool/index.md
+++ b/docs/developer/protocol/guides/manage-a-pool/index.md
@@ -9,57 +9,6 @@ contributors:
 
 This guide outlines how to manage a pool on the Centrifuge protocol.
 
-## Price updates
-
-Each pool on the Centrifuge protocol can have multiple share classes. The price of each share token must be maintained and updated to reflect its current value. This price is managed at the protocol level through the Hub contract.
-
-To update the token price for a specific share class in a pool, call the following function on the Hub:
-
-```solidity
-hub.updateSharePrice(poolId, scId, sharePrice, uint64(block.timestamp));
-```
-
-* `poolId`: the unique identifier of the pool
-* `scId`: the identifier of the share class within the pool
-* `sharePrice`: the new price of the share token (18 decimal fixed point integer)
-* `uint64(block.timestamp)`: timestamp when the price was computed
-
-:::info[On-chain pricing]
-Currently, the pricing mechanism is intended to be provided by an off-chain computation. In the future, on-chain price calculations will be implemented, using the holdings and double-entry bookkeeping accounting mechanism of the Hub.
-:::
-
-### Pushing to price oracles
-
-After updating the share token price, it must be pushed to the price oracle on each deployed network. This ensures that other contracts and off-chain components can retrieve the latest share price.
-
-To notify the price oracle, call the following function:
-
-```solidity
-hub.notifySharePrice{value: gas}(poolId, scId, centrifugeId, msg.sender);
-```
-
-* `poolId`: the identifier of the pool whose share price was updated
-* `scId`: the share class identifier for which the price was updated
-* `centrifugeId`: the network identifier where the oracle should receive the updated price
-* `gas`: The amount of native currency to cover cross-chain messaging costs (excess will be refunded)
-* `msg.sender`: Address to receive any excess gas refund
-
-
-### Updating and pushing asset prices
-
-Since multiple assets can be used to invest in the same pool, the price of the asset denominated in the currency of the pool (e.g. USD) also needs to be set.
-
-By default, this price is assumed to be `1.0`, implying a 1-to-1 peg between all assets.
-
-This needs to be pushed to the asset price oracle on each network once:
-
-```solidity
-hub.notifyAssetPrice{value: gas}(poolId, scId, assetId, msg.sender);
-```
-
-* `gas`: The amount of native currency to cover cross-chain messaging costs (excess will be refunded)
-* `msg.sender`: Address to receive any excess gas refund
-
 ## Managing investment requests
 
 Investment requests, whether deposits or redemptions, are submitted by users through vaults operating on various chains. Despite being initiated on different networks, these requests are managed centrally on the Hub chain. This ensures consistent processing and coordination across the entire protocol.

--- a/docs/developer/protocol/guides/manage-assets/_category_.yml
+++ b/docs/developer/protocol/guides/manage-assets/_category_.yml
@@ -1,1 +1,1 @@
-position: 5
+position: 6

--- a/docs/developer/protocol/guides/publish-nav-and-oracles/_category_.yml
+++ b/docs/developer/protocol/guides/publish-nav-and-oracles/_category_.yml
@@ -1,0 +1,1 @@
+position: 3

--- a/docs/developer/protocol/guides/publish-nav-and-oracles/index.md
+++ b/docs/developer/protocol/guides/publish-nav-and-oracles/index.md
@@ -1,0 +1,61 @@
+---
+id: publish-nav-and-oracles
+title: NAV and oracles
+category: subpage
+---
+
+# NAV and oracles
+
+Centrifuge has a built-in Net Asset Value oracle. This **primary NAV** is set by the issuer and is the protocol's onchain source of truth for a pool's value and share price. It is enough to run a pool end to end.
+
+The primary NAV is already consumable onchain by other protocols. On top of it, you can optionally work with third-party oracle providers such as Chronicle to add an independent verification layer, which some DeFi integrations prefer.
+
+## How the primary NAV is published
+
+The issuer sets the primary NAV by publishing a share price to the Hub, which holds the protocol's source of truth. A pool can have multiple share classes, and each has its own price that is kept up to date to reflect its current value.
+
+A pool's NAV is typically computed offchain, for example from a portfolio held with a bank or custodian. The issuer publishes the resulting share price to the Hub:
+
+```solidity
+hub.updateSharePrice(poolId, scId, sharePrice, uint64(block.timestamp));
+```
+
+* `poolId`: the unique identifier of the pool
+* `scId`: the identifier of the share class within the pool
+* `sharePrice`: the new price of the share token (18 decimal fixed point integer)
+* `uint64(block.timestamp)`: timestamp when the price was computed
+
+This published share price is the pool's reference price across all networks. The execution price for individual deposit and redemption batches is set separately in the `BatchRequestManager` (see [Manage a pool](/developer/protocol/guides/manage-a-pool#managing-investment-requests)).
+
+### Pushing to price oracles
+
+After updating the share price, push it to the price oracle on each network where the share token is deployed. This lets other contracts and offchain components retrieve the latest price.
+
+```solidity
+hub.notifySharePrice{value: gas}(poolId, scId, centrifugeId, msg.sender);
+```
+
+* `poolId`: the identifier of the pool whose share price was updated
+* `scId`: the share class identifier for which the price was updated
+* `centrifugeId`: the network identifier where the oracle should receive the updated price
+* `gas`: the amount of native currency to cover cross-chain messaging costs (excess is refunded)
+* `msg.sender`: address to receive any excess gas refund
+
+### Updating and pushing asset prices
+
+Since multiple assets can be used to invest in the same pool, the price of each asset denominated in the pool currency (for example, USD) also needs to be set. By default this price is assumed to be `1.0`, implying a 1-to-1 peg between all assets.
+
+This needs to be pushed to the asset price oracle on each network once:
+
+```solidity
+hub.notifyAssetPrice{value: gas}(poolId, scId, assetId, msg.sender);
+```
+
+* `gas`: the amount of native currency to cover cross-chain messaging costs (excess is refunded)
+* `msg.sender`: address to receive any excess gas refund
+
+## Integrating a third-party oracle
+
+A third-party oracle such as Chronicle lives in its own contract. To bring its value onchain into the pool, use a small wrapper that reads the oracle and calls `hub.updateSharePrice()`. The [Pushing to price oracles](#pushing-to-price-oracles) step then propagates it across networks.
+
+This is separate from the per-asset accounting setup, where individual holdings are valued onchain to compute NAV. For that, see [Set up onchain valuation](/developer/protocol/guides/setup-onchain-valuation).

--- a/docs/developer/protocol/guides/setup-onchain-valuation/_category_.yml
+++ b/docs/developer/protocol/guides/setup-onchain-valuation/_category_.yml
@@ -1,1 +1,1 @@
-position: 7
+position: 8


### PR DESCRIPTION
## What

### New guide: NAV and oracles
`docs/developer/protocol/guides/publish-nav-and-oracles/` — explains:
- **Primary NAV**: Centrifuge's built-in NAV oracle, set by the issuer via `hub.updateSharePrice` / `notifySharePrice` (and asset prices via `notifyAssetPrice`). This is the source of truth for a pool's value and share price.
- **Third-party oracles** (e.g. Chronicle): optional, layered on top for independent verification and DeFi consumption, wired in via a small wrapper that calls `hub.updateSharePrice`. Kept distinct from the per-asset onchain valuation path (which links to *Set up onchain valuation*).

The price-publishing mechanics were moved here out of *Manage a pool* (which now focuses on the request lifecycle), and the guide is slotted in at position 3, right after *Manage a pool*.

### FAQ: preferred way to read the current share price
In *Invest into a vault* → "How do I get the current share price?", lead with `vault.pricePerShare()` (price of one share in the asset's decimals) as the preferred option, keeping `convertToAssets()` as the alternative.
